### PR TITLE
Fix typo in item healing comment

### DIFF
--- a/python/atividade_jogo/main.py
+++ b/python/atividade_jogo/main.py
@@ -58,7 +58,7 @@ class PersonagemGame:
 
     def usar_item(self, item: str) -> bool:
         if self.inventario.remover_item(item):
-            cura = 20  # cira fixa
+            cura = 20  # cura fixa
             self.vida += cura
             print(f"{self.nome} usou {item}, +{cura} vida (vida {self.vida})")
             return True


### PR DESCRIPTION
## Summary
- fix a minor typo in `python/atividade_jogo/main.py`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f9cdf94288327ae7aefb7a97e4f43