### PR TITLE
Fix comment typo in c/basico main

### DIFF
--- a/c/basico/funcoes/main.c
+++ b/c/basico/funcoes/main.c
@@ -1,7 +1,7 @@
 
 // [] Programação estruturada: Quais problemas resolve?
 
-// [] função main (com e sem argumentos, quaantos e quais?)
+// [] função main (com e sem argumentos, quantos e quais?)
 
 
 // [] funções Void e Tipos de retorno (EXIT_SUCCESS / EXIT_FAILURE)


### PR DESCRIPTION
## Summary
- correct spelling mistake in funcoes/main.c comment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f9cde6cc483278bd5005e08f6803e